### PR TITLE
travisci: use cargo check instead of cargo build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,6 +19,6 @@ script:
   - cargo fmt --all -- --check &&
    cargo clippy -- -D warnings &&
    cargo test --verbose &&
-   cargo build --verbose
+   cargo check --verbose
 
 cache: cargo


### PR DESCRIPTION
We're not releasing anything yet so there's no need to generate a build artifact